### PR TITLE
Wire up run button

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "command": "ehrql.debug",
         "title": "OpenSAFELY: Debug ehrQL dataset",
         "icon": "$(play)",
-        "enablement": "editorTextFocus && resourceLangId == python"
+        "enablement": "editorTextFocus && resourceLangId == python && isEhrqlFile"
       }
     ],
     "menus": {
@@ -38,7 +38,7 @@
             {
                 "command": "ehrql.debug",
                 "group": "navigation",
-                "when": "editorTextFocus && resourceLangId == python"
+                "when": "editorTextFocus && resourceLangId == python && isEhrqlFile"
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -28,9 +28,20 @@
     "commands": [
       {
         "command": "ehrql.debug",
-        "title": "OpenSAFELY: Debug ehrQL dataset"
+        "title": "OpenSAFELY: Debug ehrQL dataset",
+        "icon": "$(play)",
+        "enablement": "editorTextFocus && resourceLangId == python"
       }
     ],
+    "menus": {
+        "editor/title/run": [
+            {
+                "command": "ehrql.debug",
+                "group": "navigation",
+                "when": "editorTextFocus && resourceLangId == python"
+            }
+        ]
+    },
     "configuration": {
       "title": "OpenSAFELY",
       "properties": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "command": "ehrql.debug",
         "title": "OpenSAFELY: Debug ehrQL dataset",
         "icon": "$(play)",
-        "enablement": "editorTextFocus && resourceLangId == python && isEhrqlFile"
+        "enablement": "resourceLangId == python && isEhrqlFile"
       }
     ],
     "menus": {
@@ -38,7 +38,7 @@
             {
                 "command": "ehrql.debug",
                 "group": "navigation",
-                "when": "editorTextFocus && resourceLangId == python && isEhrqlFile"
+                "when": "resourceLangId == python && isEhrqlFile"
             }
         ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,19 +5,11 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { exec } from 'child_process';
 
-let statusBarItem: vscode.StatusBarItem;
 let debugPanel: vscode.WebviewPanel | undefined;
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
-
-	// Create a status bar item that runs the display command
-    statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
-    statusBarItem.command = 'ehrql.debug';
-	statusBarItem.text = "Debug ehrQL";
-	statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
-
 
 	// Implement the display command defined in the package.json file
 	const disposable = vscode.commands.registerCommand('ehrql.debug', () => {
@@ -45,9 +37,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 		// Check that the dummy tables path exists
 		const dummyTablesPath = path.join(workspaceFolder.uri.fsPath, dummyTablesDir);
-		if (fs.existsSync(dummyTablesPath)) {
-			statusBarItem.tooltip = `Debug dataset using dummy tables in ${dummyTablesDir}/`;
-		} else {
+		if (!fs.existsSync(dummyTablesPath)) {
 			vscode.window.showErrorMessage(`Dummy table path ${dummyTablesDir}/ not found`);
 			return;
 		}
@@ -127,13 +117,7 @@ export function activate(context: vscode.ExtensionContext) {
 		});
 	});
 
-	// Watch for active editor changes to update status bar visibility
-	context.subscriptions.push(disposable, statusBarItem);
-	context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor(updateStatusBarVisibility));
-	context.subscriptions.push(vscode.window.onDidChangeTextEditorSelection(updateStatusBarVisibility));
-
-    // Initialize visibility based on current editor
-    updateStatusBarVisibility();
+	context.subscriptions.push(disposable);
 }
 
 function getWebviewContent(stderr: string, stdout: string, css_uri: vscode.Uri): string {
@@ -156,19 +140,3 @@ function getWebviewContent(stderr: string, stdout: string, css_uri: vscode.Uri):
 	`;
   }
 
-
-function updateStatusBarVisibility() {
-	const editor = vscode.window.activeTextEditor;
-    if (editor && editor.document.languageId === 'python') {
-        statusBarItem.show();
-    } else {
-        statusBarItem.hide();
-    }
-}
-
-
-export function deactivate() {
-	if (statusBarItem) {
-		statusBarItem.dispose();
-	}
-}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// Implement the debug command defined in the package.json file
 	const disposable = vscode.commands.registerCommand('ehrql.debug', () => {
-	
+
 		const editor = vscode.window.activeTextEditor;
 
 		if (!editor) {
@@ -98,7 +98,6 @@ export function activate(context: vscode.ExtensionContext) {
 		// Get the filename relative to the workspace folder
         const fileName = editor.document.fileName.replace(workspaceFolder.uri.fsPath + "/", "");
 
-
 		// Define the command
 		const command = `"${opensafelyPath}" exec ehrql:"${imageVersion}" debug "${fileName}" --dummy-tables "${dummyTablesDir}" --display-format html`;
 
@@ -119,7 +118,6 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(disposable);
 	context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor(updateEhrqlContext));
-	context.subscriptions.push(vscode.window.onDidChangeTextEditorSelection(updateEhrqlContext));
 
 }
 


### PR DESCRIPTION
Fixes #9 

- Adds the OpenSAFELY ehrql command to the the Run menu (in the navigation group, so it's at the top and the default)
- Add some additional config for whether to show and enable the command (a text editor has focus and it's a python file)
- Removes the status bar button
- Does a very cursory check to decide if it could be an ehrql dataset definition and sets a context variable. The context variable is used in the package.json config to determine whether the Run menu option should be shown, and whether the command is enabled.

![Screenshot from 2024-12-04 15-43-09](https://github.com/user-attachments/assets/391cf40f-1eaf-456b-bd1d-8767ea55873b)
