### PR TITLE
Add loading text while extension runs the ehrQL command

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -94,6 +94,8 @@ export function activate(context: vscode.ExtensionContext) {
 			// Handle the panel disposal to clean up
 			debugPanel.onDidDispose(() => { debugPanel = undefined; }, null);
 		}
+		
+		debugPanel!.webview.html = 'Loading...';
 
 		// Get the filename relative to the workspace folder
         const fileName = editor.document.fileName.replace(workspaceFolder.uri.fsPath + "/", "");


### PR DESCRIPTION
Adds the 'Loading...' text to the debug panel when the button is hit, which is replaced by the output once the ehrQL command has run.