### PR TITLE
Publish 1.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opensafely",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opensafely",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "devDependencies": {
         "@types/mocha": "^10.0.9",
         "@types/node": "^20.19.43",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "repository": "https://github.com/opensafely-core/opensafely-vscode",
   "description": "Tools for working with OpenSAFELY code",
   "publisher": "bennettoxford",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "engines": {
     "vscode": "^1.95.0",
     "node": ">=20.18.0"


### PR DESCRIPTION
Ran `just publish patch`

Version 1.3.3 is now available on the VSCode marketplace:

>  INFO  Publishing 'bennettoxford.opensafely v1.3.3'...
>  INFO  Extension URL (might take a few minutes): https://marketplace.visualstudio.com/items?itemName=bennettoxford.opensafely
>  DONE  Published bennettoxford.opensafely v1.3.3.